### PR TITLE
Add pcingola/a2a_min SDK to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,73 +38,72 @@ AI clients that can interact with A2A servers:
 
 ## Legend
 
-* 👖‍ — official implementation
+* 🎖️ – official implementation
 * programming language
-  * 🐍 — Python codebase
-  * 📗 — TypeScript/JavaScript codebase
-  * 🏎️‍ — Go codebase
-  * 🦀 — Rust codebase
-  * #️⃣🎮 - C# Codebase
+  * 🐍 – Python codebase
+  * 📇 – TypeScript/JavaScript codebase
+  * 🏎️ – Go codebase
+  * 🦀 – Rust codebase
+  * #️⃣ - C# Codebase
   * ☕ - Java codebase
 * scope
-  * ⚁‍ - Cloud Service
+  * ☁️ - Cloud Service
   * 🏠 - Local Service
   * 📟 - Embedded Systems
 * operating system
-  * 🍎 — For macOS
-  * 🏯 — For Windows
+  * 🍎 – For macOS
+  * 🪟 – For Windows
   * 🐧 - For Linux
 
 > [!NOTE]
-> Confused about Local 🏠 vs Cloud ⚁‍?
+> Confused about Local 🏠 vs Cloud ☁️?
 > * Use local when A2A server is talking to a locally installed software.
 > * Use cloud when A2A server is talking to remote APIs, like Google Maps API.
 
 ## Server Implementations
 
-* 👖‍ - [Official Samples](#official-samples)
-* 🗺️‍ - [Location Services](#location-services)
-* 🏢 - [Business Tools](#business-tools)
-* 🖼️‍ - [Image Generation](#image-generation)
-* 🏦 - [Financial Services](#financial-services)
+* 🎖️ - [Official Samples](#official-samples)
+* 🗺️ - [Location Services](#location-services)
+* 💼 - [Business Tools](#business-tools)
+* 🖼️ - [Image Generation](#image-generation)
+* 💱 - [Financial Services](#financial-services)
 * 🔎 - [Search & Data Extraction](#search-and-data-extraction)
-* 🏬 - [Communication Services](#communication-services)
+* 💬 - [Communication Services](#communication-services)
 * 🔄 - [Integration Services](#integration-services)
-* 👨‍💻‍ - [Developer Tools](#developer-tools)
+* 🛠️ - [Developer Tools](#developer-tools)
 * 🧠 - [Knowledge Services](#knowledge-services)
 * 📊 - [Data Services](#data-services)
-* 🎓 - [Educational Tools](#educational-tools)
 * 🚆 - [Travel & Transportation](#travel-and-transportation)
 
-### 👖‍ <a name="official-samples"></a>Official Samples
+### 🎖️ <a name="official-samples"></a>Official Samples
 
 Official sample implementations from the Google A2A repository.
 
-- [google/google_adk](https://github.com/google/A2A/tree/main/samples/python/agents/google_adk) 👖‍ 🐍 🏠 - An expense reimbursement agent built with Google Agent Development Kit (ADK). Showcases multi-turn interactions and webform handling through the A2A protocol.
+- [google/google_adk](https://github.com/google/A2A/tree/main/samples/python/agents/google_adk) 🎖️ 🐍 🏠 - An expense reimbursement agent built with Google Agent Development Kit (ADK). Showcases multi-turn interactions and webform handling through the A2A protocol.
 
-- [google/langgraph](https://github.com/google/A2A/tree/main/samples/python/agents/langgraph) 👖‍ 🐍 ⚁‍ - A currency conversion agent built with LangGraph. Showcases multi-turn interactions, tool usage for currency exchange via Frankfurter API, and streaming updates through the A2A protocol.
+- [google/langgraph](https://github.com/google/A2A/tree/main/samples/python/agents/langgraph) 🎖️ 🐍 ☁️ - A currency conversion agent built with LangGraph. Showcases multi-turn interactions, tool usage for currency exchange via Frankfurter API, and streaming updates through the A2A protocol.
 
-- [google/crewai](https://github.com/google/A2A/tree/main/samples/python/agents/crewai) 👖‍ 🐍 ⚁‍ - An image generation agent built with CrewAI. Showcases text-to-image generation using Google Gemini API and returning images as artifacts through the A2A protocol.
+- [google/crewai](https://github.com/google/A2A/tree/main/samples/python/agents/crewai) 🎖️ 🐍 ☁️ - An image generation agent built with CrewAI. Showcases text-to-image generation using Google Gemini API and returning images as artifacts through the A2A protocol.
 
-### 🗺️‍ <a name="location-services"></a>Location Services
+### 🗺️ <a name="location-services"></a>Location Services
 
 A2A servers providing mapping, geocoding, navigation, and other location-based services.
 
-- [pab1it0/google-maps-a2a](https://github.com/pab1it0/google-maps-a2a) 🐍 ⚁‍ - An A2A-compliant server that provides Google Maps capabilities including geocoding, reverse geocoding, directions, places search, place details, and distance matrix calculations. Supports multiple input/output formats and provides a standardized agent card for capability discovery.
+- [pab1it0/google-maps-a2a](https://github.com/pab1it0/google-maps-a2a) 🐍 ☁️ - An A2A-compliant server that provides Google Maps capabilities including geocoding, reverse geocoding, directions, places search, place details, and distance matrix calculations. Supports multiple input/output formats and provides a standardized agent card for capability discovery.
 
-### 🏢 <a name="business-tools"></a>Business Tools
+### 💼 <a name="business-tools"></a>Business Tools
 
 A2A servers for business operations, expense management, and other enterprise functions.
 
 *See [google/google_adk](#official-samples) for an example expense reimbursement tool.*
 
-### 🖼️‍ <a name="image-generation"></a>Image Generation
+### 🖼️ <a name="image-generation"></a>Image Generation
 
 A2A servers for generating and manipulating images.
 
 *See [google/crewai](#official-samples) for an example image generation tool.*
 
-### 🏦 <a name="financial-services"></a>Financial Services
+### 💱 <a name="financial-services"></a>Financial Services
 
 A2A servers for financial operations, currency conversion, and financial data.
 
@@ -116,7 +115,7 @@ A2A servers for search, data retrieval, and information extraction.
 
 *No additional entries yet. [Contribute](CONTRIBUTING.md)!*
 
-### 🏬 <a name="communication-services"></a>Communication Services
+### 💬 <a name="communication-services"></a>Communication Services
 
 A2A servers for messaging, email, and other communication tools.
 
@@ -128,7 +127,7 @@ A2A servers that bridge to various APIs, platforms, and services.
 
 *No entries yet. [Contribute](CONTRIBUTING.md)!*
 
-### 👨‍💻‍ <a name="developer-tools"></a>Developer Tools
+### 🛠️ <a name="developer-tools"></a>Developer Tools
 
 A2A servers for software development, coding, version control, and DevOps.
 
@@ -146,12 +145,6 @@ A2A servers for data processing, analytics, and database integration.
 
 *No entries yet. [Contribute](CONTRIBUTING.md)!*
 
-### 🎓 <a name="educational-tools"></a>Educational Tools
-
-A2A servers for education, learning, and training.
-
-- [hope106/multiplication_agent](https://github.com/hope106/multiplication_agent) 🐍 🏠 - A multi-agent system featuring a supervisor agent, a problem generator agent, and an answer provider agent working together to teach multiplication tables. The system demonstrates agent-to-agent communication with WebSocket real-time updates, AI explanation generation via Claude API, and a Vue.js-based web interface.
-
 ### 🚆 <a name="travel-and-transportation"></a>Travel & Transportation
 
 A2A servers for travel planning, booking, and transportation services.
@@ -162,7 +155,7 @@ A2A servers for travel planning, booking, and transportation services.
 
 Tools and frameworks for building A2A servers.
 
-- [Google Agent Development Kit (ADK)](https://github.com/google/A2A) 👖‍ 🐍 - Google's framework for building A2A-compliant agents.
+- [Google Agent Development Kit (ADK)](https://github.com/google/A2A) 🎖️ 🐍 - Google's framework for building A2A-compliant agents.
 - [LangGraph](https://github.com/langchain-ai/langgraph) 🐍 - A framework for building stateful, multi-actor applications with LLMs, with A2A support.
 - [CrewAI](https://github.com/crewai/crewai) 🐍 - Framework for orchestrating role-playing, autonomous AI agents with A2A support.
 
@@ -170,7 +163,7 @@ Tools and frameworks for building A2A servers.
 
 Auxiliary tools that help with A2A server development, testing, and deployment.
 
-*No entries yet. [Contribute](CONTRIBUTING.md)!*
+- [pcingola/a2a_min](https://github.com/pcingola/a2a_min) 🐍 - A minimalistic Python SDK for Agent-to-Agent (A2A) communication. Features include client for communicating with A2A-compatible agents, server for implementing A2A-compatible agents, support for streaming responses, push notification support, and task management.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

This PR adds the [pcingola/a2a_min](https://github.com/pcingola/a2a_min) Python SDK to the Utilities section.

### About a2a_min

a2a_min is a minimalistic Python SDK for Agent-to-Agent (A2A) communication that provides:
- Client for communicating with A2A-compatible agents
- Server for implementing A2A-compatible agents
- Support for streaming responses
- Push notification support
- Task management

The SDK helps developers build A2A-compliant applications with minimal dependencies, making it a useful utility for the A2A ecosystem.

## Checklist
- [x] I have followed the formatting guidelines in the CONTRIBUTING.md
- [x] The addition is relevant to A2A protocol
- [x] The description is brief but informative
- [x] The entry is placed in the appropriate section