### PR TITLE
Add OpenAgents to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Tools and frameworks for building A2A servers.
 - [LangGraph](https://github.com/langchain-ai/langgraph) 🐍 - A framework for building stateful, multi-actor applications with LLMs, with A2A support.
 - [CrewAI](https://github.com/crewai/crewai) 🐍 - Framework for orchestrating role-playing, autonomous AI agents with A2A support.
 - [Retool Agents](https://docs.retool.com/agents/concepts/a2a) ☁️ - Framework for building operational agents on top of business data with A2A support. 
+- [OpenAgents](https://github.com/openagents-org/openagents) 🐍 - Open-source multi-agent platform with native A2A protocol support, plus MCP, WebSocket, gRPC, and HTTP. Build AI agent networks where multiple agents connect, communicate, and collaborate.
 
 ## Utilities
 


### PR DESCRIPTION
## Summary
- Adds **[OpenAgents](https://github.com/openagents-org/openagents)** to the Frameworks section
- OpenAgents is an open-source multi-agent platform with native A2A protocol support, plus MCP, WebSocket, gRPC, and HTTP
- Apache 2.0 licensed, available on [PyPI](https://pypi.org/project/openagents/)

## Details
OpenAgents enables building AI agent networks where multiple agents connect, communicate, and collaborate over multiple protocols including A2A. It fits naturally in the Frameworks section alongside ADK, LangGraph, and CrewAI.

- **Website:** https://openagents.org
- **GitHub:** https://github.com/openagents-org/openagents
- **License:** Apache 2.0