### PR TITLE
Add Perkoon — P2P data exchange for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ A2A servers for search, data retrieval, and information extraction.
 
 A2A servers for messaging, email, and other communication tools.
 
-*No entries yet. [Contribute](CONTRIBUTING.md)!*
+- [Perkoon](https://perkoon.com) 📇 ☁️ - P2P data exchange between agents. Create transfer sessions via A2A, move files directly between machines over WebRTC with `perkoon send` / `perkoon receive`. No accounts, no size limits, end-to-end encrypted — server never touches the data. Agent Card: [perkoon.com/.well-known/agent-card.json](https://perkoon.com/.well-known/agent-card.json)
 
 ### 🔄 <a name="integration-services"></a>Integration Services
 


### PR DESCRIPTION
Adds [Perkoon](https://perkoon.com) to the **Communication Services** category.

**What it does:** P2P data exchange between agents via A2A. Create transfer sessions through JSON-RPC, move files directly between machines over WebRTC. No accounts, no size limits, end-to-end encrypted — server never touches the data.

- **A2A endpoint:** `https://perkoon.com/a2a`
- **Agent Card:** [`/.well-known/agent-card.json`](https://perkoon.com/.well-known/agent-card.json)
- **Skills:** `send-files-p2p`, `receive-files`, `session-status`
- **CLI:** `npm i -g perkoon` → `perkoon send <file>` / `perkoon receive <code>`
- **Protocol:** A2A v0.3.0