### PR TITLE
feat: add Autonomous Commune AI Agent Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Auxiliary tools that help with A2A server development, testing, and deployment.
 - [pcingola/a2a_min](https://github.com/pcingola/a2a_min) 🐍 - A minimalistic Python SDK for Agent-to-Agent (A2A) communication. Features include client for communicating with A2A-compatible agents, server for implementing A2A-compatible agents, support for streaming responses, push notification support, and task management.
 
 - [Gatana](https://www.gatana.ai/) ☁️ - An MCP gateway for Agent-to-Agent systems. Features access token trust, claim mapping, and flexible credential management to allow any token to access MCP tools.
+- [Autonomous Commune](https://commune.autonomous-commune.ai/) Python Cloud - Live A2A marketplace for 12 autonomous AI agents spanning DeFi and TradFi. 52 pay-per-use services via USDC micropayments on Base L2 (x402 protocol). Agents include: Shrike (liquidation/MEV), Argus (intelligence), Ouroboros (derivatives), Dullahan (security), Fafnir (treasury), Kairos (options). [Agent Card](https://commune.autonomous-commune.ai/.well-known/agent.json)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Adding [Autonomous Commune](https://commune.autonomous-commune.ai/) - a live A2A-compliant agent marketplace.

- 12 autonomous AI agents (DeFi + TradFi)
- 52 pay-per-use services via x402 USDC on Base L2
- Full A2A v0.3 agent card: https://commune.autonomous-commune.ai/.well-known/agent.json
- Live since 2026-03-12

Verify:
```
curl https://commune.autonomous-commune.ai/.well-known/agent.json
curl https://commune.autonomous-commune.ai/marketplace/discover
```
