### PR TITLE
docs: update Andru entry — Operational Empathy positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ A2A servers for business operations, expense management, and other enterprise fu
 
 *See [google/google_adk](#official-samples) for an example expense reimbursement tool.*
 
-- [geter-andru/mcp-server-andru-intelligence](https://github.com/geter-andru/mcp-server-andru-intelligence) 📇 ☁️ - Revenue intelligence for technical SaaS founders. 18 tools for ICP scoring, persona simulation, competitive positioning, deal classification, investor matching, and founder wellness. AP2 payment-capable. [Agent Card](https://hs-andru-test.onrender.com/.well-known/agent.json)
+- [geter-andru/mcp-server-andru-intelligence](https://github.com/geter-andru/mcp-server-andru-intelligence) 📇 ☁️ - Operational empathy for technical SaaS founders. 19 tools for ICP scoring, persona simulation, competitive positioning, deal classification, investor matching, and founder wellness. AP2 payment-capable. [Agent Card](https://hs-andru-test.onrender.com/.well-known/agent.json)
 
 - [Writbase/writbase](https://github.com/Writbase/writbase) 📇 ☁️ - MCP-native task management for AI agent fleets with multi-agent permissions, full provenance, inter-agent task delegation, and A2A status mapping.
 


### PR DESCRIPTION
Updates the Andru entry description to reflect our new positioning:

**Before:** "Revenue intelligence for technical SaaS founders. 18 tools..."
**After:** "Operational empathy for technical SaaS founders. 19 tools..."

This aligns with our rebrand from "Revenue Intelligence" to "Operational Empathy" — understanding the person across every high-stakes B2B interaction.