### PR TITLE
Add JamJet — durable agent runtime with native A2A + MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Tools and frameworks for building A2A servers.
 - [Google Agent Development Kit (ADK)](https://github.com/google/A2A) 🎖️ 🐍 - Google's framework for building A2A-compliant agents.
 - [LangGraph](https://github.com/langchain-ai/langgraph) 🐍 - A framework for building stateful, multi-actor applications with LLMs, with A2A support.
 - [CrewAI](https://github.com/crewai/crewai) 🐍 - Framework for orchestrating role-playing, autonomous AI agents with A2A support.
+- [JamJet](https://github.com/jamjet-labs/jamjet) 🦀 🐍 - Durable, agent-native AI runtime with native A2A support. Rust core with Python authoring. Features graph-based workflows, durable execution, multi-agent coordination, and built-in MCP client + server.
 - [Retool Agents](https://docs.retool.com/agents/concepts/a2a) ☁️ - Framework for building operational agents on top of business data with A2A support. 
 - [OpenAgents](https://github.com/openagents-org/openagents) 🐍 - Open-source multi-agent platform with native A2A protocol support, plus MCP, WebSocket, gRPC, and HTTP. Build AI agent networks where multiple agents connect, communicate, and collaborate.
 


### PR DESCRIPTION
## Summary

Adds [JamJet](https://github.com/jamjet-labs/jamjet) to the Frameworks section.

- **Rust core** for performance, **Python authoring** for ergonomics
- Native A2A protocol support
- Native MCP client + server support
- Graph-based workflows with durable execution
- Multi-agent coordination with dynamic routing

Website: https://jamjet.dev