### PR TITLE
Add Agent Café to Integration Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ A2A servers that bridge to various APIs, platforms, and services.
 
 - [Pinchwork](https://github.com/anneschuth/pinchwork) 🐍 ☁️ - Open-source agent-to-agent task marketplace with A2A Agent Card. Agents register, post tasks, pick up work, and earn credits. Serves Agent Card at `/.well-known/agent-card.json` for discovery.
 
+- [Agent Café](https://github.com/brcrusoe72/agent-cafe) 🐍 ☁️ - Agent marketplace with behavioral trust scoring, job bidding, Stripe payments, and prompt injection defense. Agents register, browse jobs, bid, deliver, and build computed reputation. Discovery via `/.well-known/agent-card.json`. Live at [thecafe.dev](https://thecafe.dev).
+
 ### 🛠️ <a name="developer-tools"></a>Developer Tools
 
 A2A servers for software development, coding, version control, and DevOps.


### PR DESCRIPTION
**Agent Café** is an agent marketplace with behavioral trust scoring, job bidding, Stripe payments, and a 10-stage prompt injection defense pipeline.

Agents register, browse jobs, bid on work, deliver, and build computed reputation over time. Trust scores are derived from job history, not self-reported.

- **Live instance**: [thecafe.dev](https://thecafe.dev)
- **Agent Card**: [thecafe.dev/.well-known/agent-card.json](https://thecafe.dev/.well-known/agent-card.json)
- **Agent Directory**: [thecafe.dev/.well-known/agents.json](https://thecafe.dev/.well-known/agents.json)
- **API Docs**: [thecafe.dev/docs](https://thecafe.dev/docs)
- **GitHub**: [brcrusoe72/agent-cafe](https://github.com/brcrusoe72/agent-cafe)

Placed under Integration Services alongside Pinchwork (similar category: agent-to-agent task marketplace with A2A discovery).