### PR TITLE
feat: add UCP JavaScript SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Tools and frameworks for building A2A servers.
 
 Auxiliary tools that help with A2A server development, testing, and deployment.
 
+- [UCP JavaScript SDK](https://github.com/OmnixHQ/ucp-js-sdk) 📇 - Runtime-validated Zod schemas and TypeScript types for the Universal Commerce Protocol. Auto-generated from the UCP JSON Schema spec with 100% coverage — checkout, orders, payments, payment handlers, fulfillment, discounts, buyer consent, AP2 mandates, discovery profiles (platform & business), identity linking, catalog, cart, and all inline enums. Supports MCP, A2A, REST, and Embedded transport bindings. Dual ESM/CJS build. Available on [npm](https://www.npmjs.com/package/@omnixhq/ucp-js-sdk).
+
 - [TheRaLabs/legion-a2a](https://github.com/TheRaLabs/legion-a2a) 🐍 - A robust Python implementation of the A2A protocol with both Pydantic v2 and dataclass model implementations. Provides type-safe communication between agents with complete support for task management, messaging, file/data transfer, status updates, and error handling. Maintained by Legion AI.
 
 - [pcingola/a2a_min](https://github.com/pcingola/a2a_min) 🐍 - A minimalistic Python SDK for Agent-to-Agent (A2A) communication. Features include client for communicating with A2A-compatible agents, server for implementing A2A-compatible agents, support for streaming responses, push notification support, and task management.


### PR DESCRIPTION
Adds the [UCP JavaScript SDK](https://github.com/OmnixHQ/ucp-js-sdk) to the Utilities section.

## What it is

The official JavaScript/TypeScript SDK for the Universal Commerce Protocol — runtime-validated Zod schemas and TypeScript types, auto-generated from the UCP JSON Schema spec. UCP is built on A2A (Agent2Agent) as one of its core transport bindings.

**Coverage:**
- Checkout, orders, payments, payment handlers, fulfillment
- Discounts, buyer consent, AP2 mandates
- Discovery profiles (platform & business), identity linking, catalog, cart
- All inline enums (15 standalone exports)

**Features:**
- 100% spec coverage — 100 schemas auto-generated from source
- Runtime validation via [Zod](https://zod.dev/) — `.parse()` and `.safeParse()`
- Supports MCP, A2A, REST, and Embedded transport bindings
- Dual ESM/CJS build — works in Node.js and bundlers
- Available on npm as [`@omnixhq/ucp-js-sdk`](https://www.npmjs.com/package/@omnixhq/ucp-js-sdk)

## Why it belongs here

UCP natively supports A2A as a transport binding. This SDK provides the TypeScript types and runtime validators needed to build A2A-compatible agentic commerce integrations.