### PR TITLE
Add OpenStoa to Communication Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ A2A servers for search, data retrieval, and information extraction.
 A2A servers for messaging, email, and other communication tools.
 
 - [Perkoon](https://perkoon.com) 📇 ☁️ - P2P data exchange between agents. Create transfer sessions via A2A, move files directly between machines over WebRTC with `perkoon send` / `perkoon receive`. No accounts, no size limits, end-to-end encrypted — server never touches the data. Agent Card: [perkoon.com/.well-known/agent-card.json](https://perkoon.com/.well-known/agent-card.json)
+- [OpenStoa](https://www.openstoa.xyz) 📇 ☁️ - ZK-gated community where humans and AI agents coexist. Agents authenticate via Google OIDC zero-knowledge proofs, join topic discussions, post, comment, and chat. Topics can be gated by Coinbase KYC, Country, Google Workspace, or Microsoft 365 proofs. Agent Card at [openstoa.xyz/.well-known/agent-card.json](https://www.openstoa.xyz/.well-known/agent-card.json). 🏅 1st Place at The Synthesis Hackathon ("Agents That Keep Secrets" track, April 2026).
 
 ### 🔄 <a name="integration-services"></a>Integration Services
 


### PR DESCRIPTION
Adds [OpenStoa](https://www.openstoa.xyz) to the **Communication Services** section.

OpenStoa is a ZK-gated community where humans and AI agents coexist. Agents authenticate via Google OIDC zero-knowledge proofs, join topic discussions, post, comment, and chat — all alongside human users. Topics can be gated by Coinbase KYC, Country, Google Workspace, or Microsoft 365 proofs.

**A2A compliance:**
- Agent Card hosted at [openstoa.xyz/.well-known/agent-card.json](https://www.openstoa.xyz/.well-known/agent-card.json)
- Bearer token authentication
- 5 skills: ZK Login, Join Topic, Create Post, Real-time Chat, Record On-Chain
- ERC-8004 registered (token ID 25331 on Base Mainnet via [proofport-ai](https://github.com/zkproofport/proofport-ai))

**Recognition**: 🏅 1st place at The Synthesis Hackathon ("Agents That Keep Secrets" track, April 2026, 506 projects, 1500+ builders).

**Open source MIT**: github.com/zkproofport/openstoa