### PR TITLE
Add AlgoVoi multi-chain A2A payment gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ A2A servers for financial operations, currency conversion, and financial data.
 
 - [MERX](https://merx.exchange) 📇 ☁️ - TRON blockchain resource exchange. Aggregates 7 energy providers with real-time best-price routing. 6 A2A skills: buy energy, get prices, analyze market, check balance, ensure resources, create standing orders. Also supports MCP (53 tools). Live at merx.exchange. [Agent Card](https://merx.exchange/.well-known/agent.json) ([GitHub](https://github.com/Hovsteder/merx-mcp))
 
+- [AlgoVoi](https://algovoi.co.uk) 🐍 ☁️ - Multi-chain, multi-protocol A2A payment gateway. Verifies on-chain payments and creates hosted checkout links across 7 chains (Algorand, VOI, Hedera, Stellar, Base, Solana, Tempo). Supports x402, MPP (IETF), and AP2 (Google Agentic Payments) on a single endpoint. 4 skills: verify-payment, create-checkout, check-status, post-twitter-checkout. Live at api1.ilovechicken.co.uk. [Agent Card](https://api1.ilovechicken.co.uk/.well-known/agent.json)
+
 ### 🔎 <a name="search-and-data-extraction"></a>Search & Data Extraction
 
 A2A servers for search, data retrieval, and information extraction.


### PR DESCRIPTION
Adding **AlgoVoi** — a production A2A payment gateway live at https://api1.ilovechicken.co.uk.

## What it does

Multi-chain, multi-protocol crypto payment verification agent that gates access to resources by verifying on-chain payments, or generates hosted checkout links for human-facing flows.

## Capabilities

- **7 chains**: Algorand, VOI, Hedera, Stellar, Base, Solana, Tempo
- **3 payment protocols on a single endpoint**: x402, MPP (IETF), AP2 (Google Agentic Payments)
- **4 A2A skills**:
  - verify-payment — verify an on-chain tx against a resource or checkout token
  - create-checkout — mint a hosted payment link (fiat amount + currency)
  - check-status — poll payment state of a checkout token
  - post-twitter-checkout — create a checkout link and reply via the tenant's X bot

## Agent card

https://api1.ilovechicken.co.uk/.well-known/agent.json

Also discoverable at the brand domain https://algovoi.co.uk/.well-known/agent.json and at alternate paths (agent-card.json, a2a.json, agents.json, ai-plugin.json). A2A-Version 0.3.

## Entry placed under

Financial Services, below the existing x402 entries (opspawn, TIAMAT, MERX) — AlgoVoi covers x402 as well but also adds MPP + AP2 support across a wider chain surface.