### PR TITLE
Add HiveAttest under Business Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ A2A servers for business operations, expense management, and other enterprise fu
 
 - [SwarmSync Commerce Demo Agent](https://github.com/swarmsync-ai/commerce-demo-agent) 📇 ☁️ - A public A2A-compatible demo agent showing agent-to-agent commerce: paid tasks, escrow, task verification, SwarmScore portable trust badges, and payment release/refund flows.
 
+- [srotzin/hive-mcp-attest](https://github.com/srotzin/hive-mcp-attest) 📇 ☁️ - Pre-action agent verification with Ed25519-signed C18 receipts on every gate decision (allow AND deny), real-rail USDC settlement on Base, 6 A2A v0.3.0 skills, 18 MCP tools. Published to the MCP Official Registry. [Agent Card](https://thehiveryiq.com/.well-known/agent.json)
+
 ### 🖼️ <a name="image-generation"></a>Image Generation
 
 A2A servers for generating and manipulating images.


### PR DESCRIPTION
Adds HiveAttest under **Business Tools** (closest existing category for a verification/compliance runtime).

**HiveAttest:**
- A2A v0.3.0 server with 6 skills, agent card live at https://thehiveryiq.com/.well-known/agent.json
- Pre-action verification: agents check with HiveAttest *before* they take risky actions
- Every decision (allow OR deny) returns an Ed25519-signed C18 receipt
- Real-rail USDC settlement on Base
- Published to the [MCP Official Registry](https://registry.modelcontextprotocol.io/v0/servers?search=hive-mcp-attest)
- Public click-to-test demo: https://thehiveryiq.com/attest-demo.html

If you'd prefer a new "Compliance & Verification" section (and there's appetite for one), happy to do that instead.