### PR TITLE
Add ah-cli to Utilities (daemon-first local A2A agent runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Auxiliary tools that help with A2A server development, testing, and deployment.
 - [EventTrader NEXUS AI](https://cymetica.com) 🐍 ☁️ - A2A-native prediction market trading platform with 50+ MCP tools, autonomous trade execution, real-time market intelligence, and multi-platform bridge federation (IronClaw, NanoClaw, ClawGig). Inter-agent DM infrastructure for cross-platform agent messaging. [Agent Card](https://cymetica.com/.well-known/agent-card.json)
 - [liujuanjuan1984/a2a-client-hub](https://github.com/liujuanjuan1984/a2a-client-hub) 🐍 🏠 - A self-hosted A2A client hub for managing and invoking multiple agents across web/mobile clients with authentication and session-aware routing.
 - [kcolbchain/switchboard](https://github.com/kcolbchain/switchboard) 🐍 - Agent-side x402 transport that composes with the a2a-x402 extension. Binary-wire `PaymentOffer` / `PaymentProof` envelopes via ZAP, HTTP 402 middleware (FastAPI/Flask), gas-budget tracker, reorg-safe nonce manager, and Solidity `AgentEscrow` for agent-to-agent settlement.
+- [annals-ai/ah-cli](https://github.com/annals-ai/ah-cli) 📇 🏠 🍎 🐧 🪟 - Daemon-first local runtime for AI agents. One local daemon runs many Claude/Codex agents with sessions and transcripts kept on your own disk; expose any agent over A2A Protocol v1.0 either to a hosted open network or as a vendor-neutral self-hosted HTTP endpoint. Local multi-agent fan-out and pipelines; WebRTC P2P file transfer between agents. MIT, `npm i -g @annals/ah-cli`.
 
 ## Contributing
 


### PR DESCRIPTION
Adds **ah-cli** to the Utilities section (bottom, format + legend markers matched: 📇 TypeScript/JS, 🏠 Local Service, cross-platform).

ah-cli is a daemon-first local runtime: Claude/Codex agents and their transcripts stay on the user's machine, and any agent can be exposed over A2A Protocol v1.0 — to a hosted open network or a vendor-neutral self-hosted endpoint. Adjacent to legion-a2a / a2a_min but local-first with multi-agent orchestration.

- Repo: https://github.com/annals-ai/ah-cli
- npm: https://www.npmjs.com/package/@annals/ah-cli
- License: MIT
- Single line added; no unrelated changes.