### PR TITLE
Add Aurelius Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ A2A servers that bridge to various APIs, platforms, and services.
 
 A2A servers for software development, coding, version control, and DevOps.
 
+- [Aurelius Agent](https://aureliusagent.dev/) ☁️ - Strategic planning and orchestration agent for BuilderStudio that breaks complex software work into actionable implementation paths, coordinates coding tasks, prepares project context, guides Hermes Agent execution, and supports repeatable build, smoke-test, and release flows. Agent Card: https://aureliusagent.dev/.well-known/agent-card.json. Docker image: `ghcr.io/wundercorp/aurelius-agent:0.3.9`. Built by wundercorp.
+
 - [EmilLindfors/a2a-rs](https://github.com/EmilLindfors/a2a-rs) 🦀 🏠 - A Rust implementation of the A2A protocol that follows idiomatic Rust practices and hexagonal architecture principles. Features both client and server implementations, multiple transport options (HTTP and WebSocket), streaming support, and async/sync interfaces with flexible feature flags.
 - [k-jarzyna/adk-modular-architecture](https://github.com/k-jarzyna/adk-modular-architecture) 🐍 🏠 - A flexible, multi-agent system for automating the presales process using Google's Agent Development Kit.
 - [yeeaiclub/a2a-go](https://github.com/yeeaiclub/a2a-go) 🏎️ 🏠 - A Go implementation of the A2A protocol with middleware support, authentication, and complete protocol methods. Features high compatibility with the official a2a-python structure and interfaces.


### PR DESCRIPTION
## Summary

Adds Aurelius Agent by wundercorp to the A2A ecosystem list.

## Why it fits

Aurelius Agent is a BuilderStudio orchestration agent focused on strategic planning, implementation coordination, project-context preparation, downstream coding-agent guidance, and repeatable build / smoke-test / release flows.

## Links

- Homepage: https://aureliusagent.dev/
- AgentCard: https://aureliusagent.dev/.well-known/agent-card.json
- A2A endpoint: https://aureliusagent.dev/a2a
- Container image: `ghcr.io/wundercorp/aurelius-agent:0.3.9`

## Validation

- [x] Public AgentCard is reachable.
- [ ] A2A endpoint URL is live and correct.
- [x] Container image is public and pullable.
- [x] License label is accurate.
