### PR TITLE
Add LogicNodes PII-Shield to Data Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ A2A servers for knowledge management, document handling, and information extract
 A2A servers for data processing, analytics, and database integration.
 
 - [Cerebrus Pulse](https://cerebruspulse.xyz) 🐍 ☁️ 🐧 - Institutional-grade crypto derivatives intelligence via A2A + x402 micropayments. Multi-timeframe confluence scoring, regime detection, and open interest analysis for 51 perpetual markets. Pay-per-query with USDC on Base. Agent Card: [api.cerebruspulse.xyz/.well-known/agent-card.json](https://api.cerebruspulse.xyz/.well-known/agent-card.json)
+- [LogicNodes PII-Shield](https://logicnodes.io) 🐍 ☁️ - A2A-discoverable PII-screening agent that returns an EIP-191-signed, on-chain-verifiable attestation per call (input_sha256 to output_sha256). Free tier 5/day, then $0.05 USDC per call via x402 on Base. Each call mints a public proof page that re-verifies the signature in the browser. Agent Card: [logicnodes.io/.well-known/agent.json](https://logicnodes.io/.well-known/agent.json)
 
 ### 🚆 <a name="travel-and-transportation"></a>Travel & Transportation
 


### PR DESCRIPTION
Adds **LogicNodes PII-Shield** to the **Data Services** section.

PII-Shield is an A2A-discoverable agent that screens text for personal data and returns an **EIP-191-signed, on-chain-verifiable attestation** for every call, binding `input_sha256 → output_sha256`. Anyone can re-verify a receipt independently:
- Free try: https://logicnodes.io/pii-shield.html
- Proof example (verifies signature in-browser): https://logicnodes.io/p/ca70122e81cb
- Agent Card: https://logicnodes.io/.well-known/agent.json

Pricing: free 5/day, then $0.05 USDC per call via x402 on Base. Entry format and emoji legend (🐍 Python, ☁️ Cloud) match the surrounding Data Services entries. Maintainer here — glad to adjust.
