### PR TITLE
Add BuyWhere MCP — A2A-compliant product catalog API for AI shopping agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ A2A servers for search, data retrieval, and information extraction.
 
 - [unitedideas/ai-dev-jobs](https://aidevboard.com/docs) 🏎️ ☁️ - AI Dev Jobs — structured data on 8,400+ active AI/ML engineering jobs from 580 ATS sources. Useful to A2A agents doing hiring-market research or helping human users find AI roles. MCP server at `https://aidevboard.com/mcp` + REST API.
 
+- [BuyWhere/buywhere-mcp](https://github.com/BuyWhere/buywhere-mcp) 📇 ☁️ - A2A-compliant product catalog API for AI shopping agents — search, compare prices, and find best deals across 163M+ products from 89K+ merchants in Singapore, US, and SEA markets. Live Agent Card at [buywhere.ai/.well-known/agent-card.json](https://buywhere.ai/.well-known/agent-card.json). Also exposes an MCP server at `https://api.buywhere.ai/mcp` for Claude Desktop, Cursor, and VS Code. ([GitHub](https://github.com/BuyWhere/buywhere-mcp))
+
 ### 💬 <a name="communication-services"></a>Communication Services
 
 A2A servers for messaging, email, and other communication tools.


### PR DESCRIPTION
## What is BuyWhere?

BuyWhere is the **A2A-compliant product catalog API** for AI shopping agents. It serves a real-time MCP + A2A interface to **163M+ products** across **89K+ merchants** in Singapore, US, and Southeast Asia markets.

## Why it fits A2A

- **Live Agent Card** at https://buywhere.ai/.well-known/agent-card.json (A2A v0.3.0 spec compliant)
- **3 A2A skills**: `product_search`, `product_compare`, `deal_finder`
- **Cloud service** ☁️ — talks to remote merchant APIs (Amazon, Shopee, Lazada, Walmart, Best Buy, etc.)
- **TypeScript** 📇 implementation
- **Also exposes MCP** at `https://api.buywhere.ai/mcp` for Claude Desktop, Cursor, VS Code

## Use cases for A2A agents

- **Price comparison** agents that need cross-merchant pricing for the same SKU
- **Deal discovery** agents that surface regional discounts (e.g. "best laptop deal in Singapore under $1500")
- **Product research** agents building shopping recommendations

## Evidence

- 163M+ products / 89K+ merchants (live)
- 4 PRs merged into top-tier MCP awesome lists in the last 7 days (ScaleLeap #39, milisp #35, JSONbored #4238, public-apis #6001)
- Live on Glama, Smithery, mcp.so, MCP Registry (official), PulseMCP, and 11 GitHub awesome lists
- A2A Agent Card: https://buywhere.ai/.well-known/agent-card.json

## Placement

Added under **Search & Data Extraction** (alphabetical, after `unitedideas/ai-dev-jobs`). Happy to move to a different section if you prefer.