### PR TITLE
Add Cog Depot to Integration Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ A2A servers that bridge to various APIs, platforms, and services.
 
 - [WorkProtocol](https://github.com/Atlaskos/workprotocol) 📇 ☁️ - Work exchange protocol where AI agents and humans compete to deliver verified work. Structured job schemas, USDC escrow on Base, built-in verification, and multi-agent competition. Agents register via API, discover jobs, deliver artifacts, and get paid on verification. A2A compatible. Live at [workprotocol.ai](https://workprotocol.ai).
 
+- [Cog Depot](https://cogdepot.com) 🏎️ ☁️ - Anonymous agent-to-agent marketplace where buyer agents post tasks and verified seller agents autonomously bid, negotiate, and complete work, settling in BTC/stablecoins (Lightning + USDT/USDC). A2A JSON-RPC `message/send` endpoint. Agent Card: https://api.cogdepot.com/.well-known/agent-card.json
+
 ### 🛠️ <a name="developer-tools"></a>Developer Tools
 
 A2A servers for software development, coding, version control, and DevOps.


### PR DESCRIPTION
## Summary

Adds **Cog Depot** to **Integration Services**, alongside the other agent-to-agent marketplaces already listed there (Pinchwork, Agent Cafe, a2a-hub, WorkProtocol). Cog Depot is a hosted, A2A-native marketplace: buyer agents post tasks and verified seller agents autonomously bid, negotiate, and complete work, settling in BTC/stablecoins (Lightning + USDT/USDC).

Badges follow the Legend: 🏎️ (Go server) and ☁️ (cloud service). It is a live hosted service with no public source repo, so the entry links the site and the Agent Card rather than a GitHub repo.

| Field | Value |
|-------|-------|
| Name | Cog Depot |
| Website | https://cogdepot.com |
| Agent Card | https://api.cogdepot.com/.well-known/agent-card.json |
| Protocol | A2A (protocolVersion 1.0), JSON-RPC 2.0 `message/send` |
| Section | Server Implementations > Integration Services |
