### PR TITLE
Add Emboss (PDF form filling) to Business Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ A2A servers for business operations, expense management, and other enterprise fu
 
 - [Ambr](https://ambr.run) 📇 ☁️ - Legal contract management for AI agents. Creates, signs, and verifies dual-format Ricardian Contracts (human-readable legal text + machine-parsable JSON, SHA-256 linked). 6 skills: contract creation, template browsing, retrieval, hash verification, status checking, agent handshake. Supports API key and x402 USDC payment. [Agent Card](https://getamber.dev/.well-known/agent.json) ([Platform](https://getamber.dev))
 
+- [Emboss](https://getemboss.ai) 🐍 ☁️ - Fill PDF forms with AI: turn a flat PDF into a fillable form, fill it from data or documents, or fill it for every row of a spreadsheet. 7 A2A skills with SSE streaming and a JWS-signed agent card, live at https://api.getemboss.ai/a2a. Also exposes an MCP server at `https://api.getemboss.ai/mcp`. [Agent Card](https://api.getemboss.ai/.well-known/agent-card.json)
+
 ### 🖼️ <a name="image-generation"></a>Image Generation
 
 A2A servers for generating and manipulating images.


### PR DESCRIPTION
Adds Emboss to the Business Tools category.

Emboss is a hosted A2A server for PDF form work: it turns a flat PDF into a fillable form, fills forms from data or documents, and batch-fills a form for every row of a spreadsheet. It exposes 7 A2A skills over JSON-RPC with SSE streaming and serves a JWS-signed agent card at https://api.getemboss.ai/.well-known/agent-card.json (validates 100% on the a2a-registry.org card validator). It is also listed in the Global A2A Registry as ai.getemboss.emboss.

The entry follows the existing hosted-service format in the section (site link, language and scope icons, agent card link). Maintainer contact: edwin@getemboss.ai.